### PR TITLE
enable x11

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,8 @@ test:
     - test -f $PREFIX/lib/pkgconfig/libva-drm.pc
     - test -f $PREFIX/lib/libva-drm.so
     - test -f $PREFIX/lib/libva-drm.so.2
+    - test -f $PREFIX/lib/libva-x11.so
+    - test -f $PREFIX/lib/libva-x11.so.2
 
 about:
   home: https://github.com/intel/libva

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   skip: true  # [not linux]
-  number: 1
+  number: 2
   # Pretty good forward compatibility
   # https://abi-laboratory.pro/index.php?view=timeline&l=libva
   run_exports:
@@ -28,7 +28,13 @@ requirements:
     - make
   host:
     - libdrm
-
+    - xorg-libx11
+    - xorg-libxext
+    - xorg-libxfixes
+  run:
+    - xorg-libx11
+    - xorg-libxext
+    - xorg-libxfixes
 test:
   commands:
     - test -f $PREFIX/include/va/va.h


### PR DESCRIPTION
Enable the x11 libva backend by providing the dependencies


<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
