### PR TITLE
Revert "Relax overlinking errors because of compatibility issues"

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ VA-API is an open-source library and API specification, which provides
 access to graphics hardware acceleration capabilities for video processing.
 It consists of a main library and driver-specific acceleration backends
 for each supported hardware vendor.
-
+ 
 
 Current build status
 ====================

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,6 +1,8 @@
 build_platform:
   linux_aarch64: linux_64
   linux_ppc64le: linux_64
+conda_build:
+  error_overlinking: true
 conda_forge_output_validation: true
 github:
   branch_name: main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   skip: true  # [not linux]
-  number: 2
+  number: 1
   # Pretty good forward compatibility
   # https://abi-laboratory.pro/index.php?view=timeline&l=libva
   run_exports:
@@ -29,10 +29,12 @@ requirements:
     - make
   host:
     - libdrm
+    - libxcb
     - xorg-libx11
     - xorg-libxext
     - xorg-libxfixes
   run:
+    - libxcb
     - xorg-libx11
     - xorg-libxext
     - xorg-libxfixes


### PR DESCRIPTION
Reverts conda-forge/libva-feedstock#37